### PR TITLE
Refactoring child matching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,31 +147,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-deque"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
-
-[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -179,12 +154,6 @@ checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
 ]
-
-[[package]]
-name = "either"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "flate2"
@@ -198,7 +167,7 @@ dependencies = [
 
 [[package]]
 name = "gxf2bed"
-version = "0.2.6"
+version = "0.2.7"
 dependencies = [
  "clap",
  "colored",
@@ -208,7 +177,6 @@ dependencies = [
  "libc",
  "log",
  "num_cpus",
- "rayon",
  "simple_logger",
  "thiserror",
 ]
@@ -221,7 +189,6 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
  "allocator-api2",
- "rayon",
 ]
 
 [[package]]
@@ -334,26 +301,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rayon"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gxf2bed"
-version = "0.2.6"
+version = "0.2.7"
 authors = ["alejandrogzi <alejandrxgzi@gmail.com>"]
 edition = "2021"
 license = "MIT"
@@ -14,7 +14,6 @@ default-run = "gxf2bed"
 
 [dependencies]
 thiserror = "1.0"
-rayon = "1.8.0"
 num_cpus = "1.16.0"
 clap = { version = "4.0", features = ["derive"] }
 libc = "0.2.151"
@@ -22,7 +21,7 @@ log = "0.4.14"
 simple_logger = "4.0.0"
 indoc = "2.0"
 colored = "2.0.0"
-hashbrown = { version = ">0.12", features = ["rayon"] }
+hashbrown = { version = ">0.12" }
 flate2 = "1.0.20"
 
 [profile.release]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
   <p align="center">
     <a href="https://img.shields.io/badge/version-0.1.0dev-green" target="_blank">
-      <img alt="Version Badge" src="https://img.shields.io/badge/version-0.2.3-green">
+      <img alt="Version Badge" src="https://img.shields.io/badge/version-0.2.7-green">
     </a>
     <a href="https://crates.io/crates/gxf2bed" target="_blank">
       <img alt="Crates.io Version" src="https://img.shields.io/crates/v/gxf2bed">

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,3 +1,6 @@
+//! The fastest GTF/GFF-to-BED converter chilling around
+//! Alejandro Gonzales-Irribarren, 2025
+
 use clap::Parser;
 use std::path::PathBuf;
 use thiserror::Error;

--- a/src/gxf.rs
+++ b/src/gxf.rs
@@ -1,8 +1,24 @@
+//! The fastest GTF/GFF-to-BED converter chilling around
+//! Alejandro Gonzales-Irribarren, 2025
+
 mod attr;
 pub use attr::*;
 
 use std::collections::BTreeSet;
 
+/// Represents a record parsed from a GXF (GTF/GFF) file.
+///
+/// This struct holds the essential fields of a GXF record, including chromosomal location,
+/// feature type, genomic coordinates, strand, frame, and a parsed attribute map.
+///
+/// # Fields
+/// * `chr` - The name of the chromosome or sequence contig.
+/// * `feature` - The feature type (e.g., "gene", "transcript", "exon").
+/// * `start` - The 0-based start coordinate of the feature.
+/// * `end` - The 1-based end coordinate of the feature.
+/// * `strand` - The strand of the feature (Forward, Reverse, or Unknown).
+/// * `frame` - The frame of the feature (e.g., "0", "1", "2", ".").
+/// * `attr` - A parsed `Attribute` map containing key-value pairs from the last field.
 #[derive(Debug, PartialEq)]
 pub struct GxfRecord<'a> {
     pub chr: String,
@@ -14,6 +30,9 @@ pub struct GxfRecord<'a> {
     pub attr: Attribute<'a>,
 }
 
+/// Represents the strand of a genomic feature.
+///
+/// This enum indicates whether a feature is on the forward (+), reverse (-), or an unknown (.) strand.
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum Strand {
     Forward,
@@ -22,6 +41,23 @@ pub enum Strand {
 }
 
 impl std::fmt::Display for Strand {
+    /// Formats the `Strand` enum into its string representation.
+    ///
+    /// `Strand::Forward` becomes `"+"`, `Strand::Reverse` becomes `"-"`, and `Strand::Unknown` becomes `"."`.
+    ///
+    /// # Arguments
+    /// * `f` - The formatter.
+    ///
+    /// # Returns
+    /// A `std::fmt::Result` indicating success or failure.
+    ///
+    /// # Example
+    /// ```rust
+    /// use gxf2bed::Strand; //  with the actual crate name
+    /// assert_eq!(format!("{}", Strand::Forward), "+");
+    /// assert_eq!(format!("{}", Strand::Reverse), "-");
+    /// assert_eq!(format!("{}", Strand::Unknown), ".");
+    /// ```
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             Strand::Forward => write!(f, "+"),
@@ -31,6 +67,48 @@ impl std::fmt::Display for Strand {
     }
 }
 
+impl std::str::FromStr for Strand {
+    type Err = &'static str;
+
+    /// Parses a string slice into a `Strand` enum.
+    ///
+    /// Recognizes `"+"` for `Forward`, `"-"` for `Reverse`, and any other string
+    /// (including an empty string) as `Unknown`.
+    ///
+    /// # Arguments
+    /// * `s` - The string slice to parse.
+    ///
+    /// # Returns
+    /// A `Result` containing the parsed `Strand` or a static string error if parsing fails.
+    ///
+    /// # Example
+    /// ```rust
+    /// use std::str::FromStr;
+    /// use gxf2bed::Strand; //  with the actual crate name
+    ///
+    /// assert_eq!(Strand::from_str("+").unwrap(), Strand::Forward);
+    /// assert_eq!(Strand::from_str("-").unwrap(), Strand::Reverse);
+    /// assert_eq!(Strand::from_str(".").unwrap(), Strand::Unknown);
+    /// assert_eq!(Strand::from_str("anything_else").unwrap(), Strand::Unknown);
+    /// ```
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "+" => Ok(Strand::Forward),
+            "-" => Ok(Strand::Reverse),
+            _ => Ok(Strand::Unknown),
+        }
+    }
+}
+
+/// Represents the type of a gene prediction record.
+///
+/// This enum helps categorize gene prediction records as either parent, child, or unknown,
+/// useful in hierarchical gene structures.
+///
+/// # Variants
+/// * `Parent` - Indicates a parent record (e.g., a gene).
+/// * `Child` - Indicates a child record (e.g., an exon or transcript belonging to a gene).
+/// * `Unknown` - The record type is not specified or recognized.
 #[derive(Debug, PartialEq)]
 pub enum RecordType {
     Parent,
@@ -38,6 +116,20 @@ pub enum RecordType {
     Unknown,
 }
 
+/// Represents a gene prediction, often derived from GXF records.
+///
+/// This struct aggregates information about a gene or transcript, including its genomic
+/// coordinates, strand, and a collection of its exons. It also includes a `record_type`
+/// to distinguish between parent (e.g., gene) and child (e.g., transcript) entries.
+///
+/// # Fields
+/// * `chr` - The chromosome name.
+/// * `start` - The 0-based start coordinate of the gene prediction.
+/// * `end` - The 1-based end coordinate of the gene prediction.
+/// * `strand` - The strand of the gene prediction.
+/// * `exons` - A `BTreeSet` of (start, end) tuples representing the exons.
+/// * `record_type` - The type of record (Parent, Child, or Unknown).
+/// * `blocks` - An optional `BTreeSet` of (start, end) tuples for additional blocks.
 #[derive(Debug, PartialEq)]
 pub struct GenePred {
     pub chr: String,
@@ -46,11 +138,25 @@ pub struct GenePred {
     pub strand: Strand,
     pub exons: BTreeSet<(u64, u64)>,
     pub record_type: RecordType,
-    pub cds_start: Option<u64>,
-    pub cds_end: Option<u64>,
+    pub blocks: Option<BTreeSet<(u64, u64)>>,
 }
 
 impl GenePred {
+    /// Creates a new, empty `GenePred` instance with default values.
+    ///
+    /// # Returns
+    /// A new `GenePred` instance.
+    ///
+    /// # Example
+    /// ```rust
+    /// use gxf2bed::{GenePred, Strand, RecordType}; //
+    /// let gene_pred = GenePred::new();
+    /// assert_eq!(gene_pred.chr, "");
+    /// assert_eq!(gene_pred.start, 0);
+    /// assert_eq!(gene_pred.strand, Strand::Unknown);
+    /// assert!(gene_pred.exons.is_empty());
+    /// assert_eq!(gene_pred.record_type, RecordType::Unknown);
+    /// ```
     pub fn new() -> Self {
         Self {
             chr: String::new(),
@@ -59,11 +165,58 @@ impl GenePred {
             strand: Strand::Unknown,
             exons: BTreeSet::new(),
             record_type: RecordType::Unknown,
-            cds_start: None,
-            cds_end: None,
+            blocks: None,
         }
     }
 
+    /// Merges another `GenePred` instance into the current one.
+    ///
+    /// This method updates the `GenePred` based on the `record_type` of the `query` instance.
+    ///
+    /// - If `query` is `RecordType::Parent`, it overwrites chromosome, start, end, strand,
+    ///   and record type, and extends the exons.
+    /// - If `query` is `RecordType::Child` or `RecordType::Unknown`, it updates the
+    ///   chromosome, strand, and end if they are initially empty or smaller,
+    ///   adjusts the start coordinate to be the minimum, and extends the exons.
+    ///   The `record_type` is set to `Child` if it wasn't already `Parent`.
+    ///
+    /// # Arguments
+    /// * `query` - The `GenePred` instance to merge from.
+    ///
+    /// # Example
+    /// ```rust
+    /// use std::collections::BTreeSet;
+    /// use gxf2bed::{GenePred, Strand, RecordType}; //
+    ///
+    /// let mut gp1 = GenePred::new();
+    /// gp1.chr = "chr1".to_string();
+    /// gp1.start = 100;
+    /// gp1.end = 200;
+    /// gp1.strand = Strand::Forward;
+    /// gp1.exons.insert((100, 150));
+    /// gp1.record_type = RecordType::Child;
+    ///
+    /// let mut gp2 = GenePred::new();
+    /// gp2.chr = "chr1".to_string();
+    /// gp2.start = 50;
+    /// gp2.end = 250;
+    /// gp2.strand = Strand::Forward;
+    /// gp2.exons.insert((50, 80));
+    /// gp2.exons.insert((200, 250));
+    /// gp2.record_type = RecordType::Child;
+    ///
+    /// gp1.merge(gp2);
+    ///
+    /// assert_eq!(gp1.chr, "chr1");
+    /// assert_eq!(gp1.start, 50);
+    /// assert_eq!(gp1.end, 250);
+    /// assert_eq!(gp1.record_type, RecordType::Child);
+    /// let mut expected_exons = BTreeSet::new();
+    /// expected_exons.insert((50, 80));
+    /// expected_exons.insert((100, 150));
+    /// expected_exons.insert((200, 250));
+    /// assert_eq!(gp1.exons, expected_exons);
+    /// ```
     pub fn merge(&mut self, query: GenePred) {
         match query.record_type {
             RecordType::Parent => {
@@ -107,51 +260,127 @@ impl GenePred {
                 }
             }
         }
-
-        if let Some(qs) = query.cds_start {
-            self.cds_start = Some(self.cds_start.map_or(qs, |cs| cs.min(qs)));
-        }
-        if let Some(qe) = query.cds_end {
-            self.cds_end = Some(self.cds_end.map_or(qe, |ce| ce.max(qe)));
-        }
     }
 
+    /// Returns the number of exons in the gene prediction.
+    ///
+    /// # Returns
+    /// The count of exons as `usize`.
+    ///
+    /// # Example
+    /// ```rust
+    /// use std::collections::BTreeSet;
+    /// use gxf2bed::{GenePred, Strand, RecordType}; //
+    /// let mut gp = GenePred::new();
+    /// gp.exons.insert((100, 200));
+    /// gp.exons.insert((300, 400));
+    /// assert_eq!(gp.get_exon_count(), 2);
+    /// ```
     pub fn get_exon_count(&self) -> usize {
         self.exons.len()
     }
 
+    /// Returns a vector containing the sizes (end coordinates) of all exons.
+    ///
+    /// Note: This returns the "end" coordinate from the `(start, end)` tuple for each exon.
+    /// In genomic contexts, this is often the length or end position, depending on how `exons`
+    /// was populated.
+    ///
+    /// # Returns
+    /// A `Vec<u64>` where each element is the end coordinate of an exon.
+    ///
+    /// # Example
+    /// ```rust
+    /// use std::collections::BTreeSet;
+    /// use gxf2bed::{GenePred, Strand, RecordType}; //
+    /// let mut gp = GenePred::new();
+    /// gp.exons.insert((10, 20));
+    /// gp.exons.insert((30, 40));
+    /// let mut sizes = gp.get_exon_sizes();
+    /// sizes.sort(); // BTreeSet iteration order is stable, but sorting ensures order for assert
+    /// assert_eq!(sizes, vec![20, 40]);
+    /// ```
     pub fn get_exon_sizes(&self) -> Vec<u64> {
         self.exons.iter().map(|item| item.1).collect()
     }
 
+    /// Returns a vector containing the start coordinates of all exons.
+    ///
+    /// # Returns
+    /// A `Vec<u64>` where each element is the start coordinate of an exon.
+    ///
+    /// # Example
+    /// ```rust
+    /// use std::collections::BTreeSet;
+    /// use gxf2bed::{GenePred, Strand, RecordType}; //
+    /// let mut gp = GenePred::new();
+    /// gp.exons.insert((10, 20));
+    /// gp.exons.insert((30, 40));
+    /// let mut starts = gp.get_exon_starts();
+    /// starts.sort();
+    /// assert_eq!(starts, vec![10, 30]);
+    /// ```
     pub fn get_exon_starts(&self) -> Vec<u64> {
         self.exons.iter().map(|item| item.0).collect()
     }
 
+    /// Returns a vector containing the relative start coordinates of all exons.
+    ///
+    /// Each relative start is calculated as `exon_start - gene_pred_start`.
+    ///
+    /// # Returns
+    /// A `Vec<u64>` where each element is the relative start coordinate of an exon.
+    ///
+    /// # Example
+    /// ```rust
+    /// use std::collections::BTreeSet;
+    /// use gxf2bed::{GenePred, Strand, RecordType};
+    /// let mut gp = GenePred::new();
+    /// gp.start = 100;
+    /// gp.exons.insert((110, 150));
+    /// gp.exons.insert((180, 200));
+    /// let mut relative_starts = gp.get_exon_starts_relative();
+    /// relative_starts.sort();
+    /// assert_eq!(relative_starts, vec![10, 80]);
+    /// ```
     pub fn get_exon_starts_relative(&self) -> Vec<u64> {
         self.exons
             .iter()
             .map(|item| {
                 if self.start > item.0 {
-                    dbg!(&self);
+                    panic!(
+                        "ERROR: exon start ({}) is less than gene prediction start ({})",
+                        item.0, self.start
+                    );
                 }
                 item.0 - self.start
             })
             .collect()
     }
 
-    pub fn get_cds_start(&self) -> u64 {
-        self.cds_start.unwrap_or(self.start)
-    }
-
-    pub fn get_cds_end(&self) -> u64 {
-        self.cds_end.unwrap_or(self.end)
-    }
-
-    pub fn get_cds(&self) -> (u64, u64) {
-        (self.get_cds_start(), self.get_cds_end())
-    }
-
+    /// Returns a tuple containing two strings:
+    /// 1. A comma-separated string of exon sizes (end coordinates), followed by a comma.
+    /// 2. A comma-separated string of relative exon start coordinates, followed by a comma.
+    ///
+    /// These formats are commonly used in various genomic file specifications.
+    ///
+    /// # Returns
+    /// A tuple `(String, String)` representing `(exon_sizes_string, exon_starts_relative_string)`.
+    ///
+    /// # Example
+    /// ```rust
+    /// use std::collections::BTreeSet;
+    /// use gxf2bed::{GenePred, Strand, RecordType};
+    /// let mut gp = GenePred::new();
+    /// gp.start = 100;
+    /// gp.exons.insert((110, 150));
+    /// gp.exons.insert((180, 200));
+    ///
+    /// let (exon_sizes, exon_starts_relative) = gp.get_exons_info();
+    /// // The order of exons in the BTreeSet is stable (sorted by tuple), so output will be consistent.
+    /// assert_eq!(exon_sizes, "150,200,");
+    /// assert_eq!(exon_starts_relative, "10,80,");
+    /// ```
     pub fn get_exons_info(&self) -> (String, String) {
         let exon_sizes = self
             .get_exon_sizes()
@@ -174,6 +403,47 @@ impl GenePred {
 }
 
 impl<'a> GxfRecord<'a> {
+    /// Parses a single line of a GXF (GTF/GFF) file into a `GxfRecord` instance.
+    ///
+    /// This function expects a tab-separated line and extracts the chromosome, feature,
+    /// start, end, strand, frame, and attributes. It also handles parsing the
+    /// `attribute` field using the provided `Attribute::parse` method.
+    ///
+    /// Panics if essential fields (chr, source, feature, start, end, score, strand, frame, attributes)
+    /// are missing from the input line.
+    ///
+    /// # Type Parameters
+    /// * `SEP` - A const generic parameter for the separator used within the attribute string.
+    ///
+    /// # Arguments
+    /// * `line` - The input line from the GXF file.
+    /// * `attribute` - The name of the attribute key to extract from the attributes column (e.g., "gene_id").
+    ///
+    /// # Returns
+    /// A `Result` containing the parsed `GxfRecord` or a `&'static str` error if the line is empty.
+    ///
+    /// # Panics
+    /// This function will panic if any of the mandatory 9 fields are missing from the input line,
+    /// or if the `start` or `end` coordinates cannot be parsed as `u64`.
+    ///
+    /// # Example
+    /// ```rust, ignore
+    /// // Assuming Attribute struct and its parse method are available
+    /// // and gxf2bed is replaced with the actual crate name.
+    /// use gxf2bed::{GxfRecord, Strand, Attribute};
+    /// use std::str::FromStr;
+    ///
+    /// let line = "chr1\tHAVANA\tgene\t1000\t5000\t.\t+\t.\tgene_id \"gene1\"; gene_name \"GeneA\";";
+    /// let attribute_name = "gene_id".to_string();
+    /// let record = GxfRecord::parse::<b';'>(line, &attribute_name).unwrap();
+    ///
+    /// assert_eq!(record.chr, "chr1");
+    /// assert_eq!(record.feature, "gene");
+    /// assert_eq!(record.start, 999); // 0-based
+    /// assert_eq!(record.end, 5000);
+    /// assert_eq!(record.strand, Strand::Forward);
+    /// assert_eq!(record.attr.feature(), "gene1"); // Assuming Attribute::parse extracts gene_id as feature
+    /// ```
     pub fn parse<const SEP: u8>(line: &'a str, attribute: &String) -> Result<Self, &'static str> {
         if line.is_empty() {
             return Err("Empty line");
@@ -182,22 +452,36 @@ impl<'a> GxfRecord<'a> {
         let mut fields = line.split('\t');
 
         let (chr, _, feature, start, end, _, strand, frame, attr) = (
-            fields.next().ok_or("Missing chrom")?,
-            fields.next().ok_or("Missing source")?,
-            fields.next().ok_or("Missing feature")?,
-            fields.next().ok_or("Missing start")?,
-            fields.next().ok_or("Missing end")?,
-            fields.next().ok_or("Missing score")?,
-            fields.next().ok_or("Missing strand")?,
-            fields.next().ok_or("Missing frame")?,
-            fields.next().ok_or("Missing attributes")?,
+            fields
+                .next()
+                .unwrap_or_else(|| panic!("ERROR: Missing chromosome from GTF records -> {line}")),
+            fields
+                .next()
+                .unwrap_or_else(|| panic!("ERROR: Missing source from GTF records -> {line}")),
+            fields
+                .next()
+                .unwrap_or_else(|| panic!("ERROR: Missing feature from GTF records -> {line}")),
+            fields
+                .next()
+                .unwrap_or_else(|| panic!("ERROR: Missing start from GTF records -> {line}")),
+            fields
+                .next()
+                .unwrap_or_else(|| panic!("ERROR: Missing end from GTF records -> {line}")),
+            fields
+                .next()
+                .unwrap_or_else(|| panic!("ERROR: Missing score from GTF records -> {line}")),
+            fields
+                .next()
+                .unwrap_or_else(|| panic!("ERROR: Missing strand from GTF records -> {line}"))
+                .parse::<Strand>()
+                .unwrap_or(Strand::Unknown),
+            fields
+                .next()
+                .unwrap_or_else(|| panic!("ERROR: Missing frame from GTF records -> {line}")),
+            fields
+                .next()
+                .unwrap_or_else(|| panic!("ERROR: Missing attributes from GTF records -> {line}")),
         );
-
-        let strand = match strand.chars().next().expect("ERROR: Strand is empty") {
-            '+' => Strand::Forward,
-            '-' => Strand::Reverse,
-            _ => Strand::Unknown,
-        };
 
         let attr = Attribute::parse::<SEP>(attr, attribute)
             .map_err(|e| format!("Error parsing attributes: {e}"))
@@ -214,6 +498,27 @@ impl<'a> GxfRecord<'a> {
         })
     }
 
+    /// Checks if the `GxfRecord` has a non-empty feature extracted from its attributes.
+    ///
+    /// This relies on the `Attribute::feature()` method to return the relevant feature string.
+    ///
+    /// # Returns
+    /// `true` if the feature string from attributes is not empty, `false` otherwise.
+    ///
+    /// # Example
+    /// ```rust, ignore
+    /// // Assuming Attribute struct and gxf2bed are available
+    /// use gxf2bed::{GxfRecord, Strand, Attribute};
+    /// use std::str::FromStr;
+    ///
+    /// let line_with_feature = "chr1\t.\tgene\t1\t100\t.\t+\t.\tgene_id \"ABC\";";
+    /// let record_with_feature = GxfRecord::parse::<b';'>(line_with_feature, &"gene_id".to_string()).unwrap();
+    /// assert!(record_with_feature.has_feature());
+    ///
+    /// let line_no_feature = "chr1\t.\tgene\t1\t100\t.\t+\t.\tgene_id \"\";";
+    /// let record_no_feature = GxfRecord::parse::<b';'>(line_no_feature, &"gene_id".to_string()).unwrap();
+    /// assert!(!record_no_feature.has_feature());
+    /// ```
     pub fn has_feature(&self) -> bool {
         !self.attr.feature().is_empty()
     }
@@ -278,8 +583,7 @@ mod tests {
             strand: Strand::Forward,
             exons: vec![(11868, 50), (12200, 100)].into_iter().collect(),
             record_type: RecordType::Parent,
-            cds_start: Some(11868),
-            cds_end: Some(12300),
+            blocks: None,
         };
 
         gene_pred.merge(query);
@@ -292,9 +596,6 @@ mod tests {
         assert_eq!(gene_pred.get_exon_sizes(), vec![50, 100]);
         assert_eq!(gene_pred.get_exon_starts(), vec![11868, 12200]);
         assert_eq!(gene_pred.get_exon_starts_relative(), vec![0, 332]);
-        assert_eq!(gene_pred.get_cds_start(), 11868);
-        assert_eq!(gene_pred.get_cds_end(), 12300);
-        assert_eq!(gene_pred.get_cds(), (11868, 12300));
         assert_eq!(
             gene_pred.get_exons_info(),
             ("50,100,".to_string(), "0,332,".to_string())

--- a/src/gxf/attr.rs
+++ b/src/gxf/attr.rs
@@ -1,7 +1,39 @@
-// use hashbrown::HashMap;
+//! The fastest GTF/GFF-to-BED converter chilling around
+//! Alejandro Gonzales-Irribarren, 2025
+
 use std::fmt::Debug;
 use thiserror::Error;
 
+/// A macro to extract a field's value from a byte slice.
+///
+/// This macro provides two rules for extracting key-value pairs from a byte slice,
+/// typically representing attributes in a GXF file. It supports both a variable separator
+/// and a literal byte separator for the key-value pairs.
+///
+/// The macro attempts to strip the `field_name` prefix, then the separator `sep`,
+/// and finally trims surrounding double quotes from the value. The extracted value
+/// is converted to a `&str` using `unsafe { std::str::from_utf8_unchecked(without_eq) }`,
+/// assuming valid UTF-8 input after stripping.
+///
+/// # Usage
+/// ```rust, ignore
+/// let bytes_data = b"gene_id \"gene1\";";
+/// let mut gene_id_val = None;
+/// let separator = b' ';
+/// extract_field!(
+///     bytes_data split by separator to
+///     b"gene_id" => &mut gene_id_val;
+/// );
+/// assert_eq!(gene_id_val, Some("gene1"));
+///
+/// let bytes_data_gff = b"ID=gene1;";
+/// let mut id_val = None;
+/// extract_field!(
+///     bytes_data_gff split by b'=' to
+///     b"ID" => &mut id_val;
+/// );
+/// assert_eq!(id_val, Some("gene1"));
+/// ```
 macro_rules! extract_field {
     ($bytes:ident split by $sep:ident to $( $field_name:expr => $output_field:expr; )+) => {
         $(
@@ -25,6 +57,40 @@ macro_rules! extract_field {
     };
 }
 
+/// Splits a byte slice by a specified byte separator and trims a leading byte from each resulting sub-slice.
+///
+/// This function is particularly useful for parsing attribute strings in GXF files
+/// where individual attributes are separated by a delimiter (e.g., `;`) and might
+/// have leading whitespace (` `).
+///
+/// # Type Parameters
+/// * `BY` - The byte to split the slice by (e.g., `b';'`).
+/// * `TRIM` - The leading byte to trim from each resulting sub-slice (e.g., `b' '`).
+///
+/// # Arguments
+/// * `bytes` - The input byte slice to split and trim.
+///
+/// # Returns
+/// An iterator over byte slices, where each slice is a segment from the original input,
+/// split by `BY` and with leading `TRIM` bytes removed.
+///
+/// # Example
+/// ```rust
+/// use gxf2bed::split_and_trim_bytes; //
+///
+/// let data = b" attr1=val1;  attr2=val2; attr3=val3";
+/// let result: Vec<&[u8]> = split_and_trim_bytes::<b';', b' '>(data).collect();
+///
+/// assert_eq!(result, vec![
+///     b"attr1=val1",
+///     b"attr2=val2",
+///     b"attr3=val3"
+/// ]);
+///
+/// let empty_data = b"";
+/// let result_empty: Vec<&[u8]> = split_and_trim_bytes::<b';', b' '>(empty_data).collect();
+/// assert!(result_empty.is_empty());
+/// ```
 #[inline(always)]
 fn split_and_trim_bytes<const BY: u8, const TRIM: u8>(bytes: &[u8]) -> impl Iterator<Item = &[u8]> {
     bytes.split(|b| *b == BY).map(|b| {
@@ -36,12 +102,60 @@ fn split_and_trim_bytes<const BY: u8, const TRIM: u8>(bytes: &[u8]) -> impl Iter
     })
 }
 
+/// Represents the attributes parsed from a GXF record.
+///
+/// This struct currently focuses on extracting a single "feature" attribute
+/// (e.g., `gene_id` or `transcript_id`) from the attribute string.
+///
+/// # Fields
+/// * `feature` - The value of the extracted feature attribute (e.g., gene ID).
 #[derive(Debug, PartialEq)]
 pub struct Attribute<'a> {
     feature: &'a str,
 }
 
 impl<'a> Attribute<'a> {
+    /// Parses an attribute string from a GXF record into an `Attribute` struct.
+    ///
+    /// This method uses the `split_and_trim_bytes` function and the `extract_field!` macro
+    /// to efficiently parse key-value pairs from the attribute string. It specifically
+    /// looks for the attribute identified by the `feature` parameter (e.g., "gene_id").
+    ///
+    /// # Type Parameters
+    /// * `SEP` - The byte separator used between the key and value within each attribute (e.g., `b' '` for GTF, `b'='` for GFF).
+    ///
+    /// # Arguments
+    /// * `line` - The attribute string portion of a GXF record.
+    /// * `feature` - The name of the attribute key to extract (e.g., "gene_id", "transcript_id").
+    ///
+    /// # Returns
+    /// A `Result` containing the parsed `Attribute` or a `ParseError` if the line is empty.
+    /// Note: If the `feature` attribute is not found, `feature()` will return an empty string.
+    ///
+    /// # Example
+    /// ```rust
+    /// use gxf2bed::{Attribute, ParseError}; //
+    ///
+    /// // Example for GTF-like attributes (space separated key-value)
+    /// let gtf_attr_line = "gene_id \"gene1\"; transcript_id \"tx1\";";
+    /// let attr = Attribute::parse::<b' '>(gtf_attr_line, &"gene_id".to_string()).unwrap();
+    /// assert_eq!(attr.feature(), "gene1");
+    ///
+    /// // Example for GFF-like attributes (equal sign separated key-value)
+    /// let gff_attr_line = "ID=gene1;Name=GeneA;";
+    /// let attr_gff = Attribute::parse::<b'='>(gff_attr_line, &"ID".to_string()).unwrap();
+    /// assert_eq!(attr_gff.feature(), "gene1");
+    ///
+    /// // Example with missing feature
+    /// let missing_feature_line = "other_attr \"val\";";
+    /// let attr_missing = Attribute::parse::<b' '>(missing_feature_line, &"gene_id".to_string()).unwrap();
+    /// assert_eq!(attr_missing.feature(), "");
+    ///
+    /// // Example with empty line
+    /// let empty_line = "";
+    /// let error = Attribute::parse::<b' '>(empty_line, &"gene_id".to_string()).unwrap_err();
+    /// assert_eq!(error, ParseError::Empty);
+    /// ```
     pub fn parse<const SEP: u8>(
         line: &'a str,
         feature: &String,
@@ -66,19 +180,39 @@ impl<'a> Attribute<'a> {
         }
     }
 
+    /// Returns the extracted feature string.
+    ///
+    /// This is an `inline(always)` function, suggesting it's very lightweight and
+    /// will likely be inlined by the compiler for performance.
+    ///
+    /// # Returns
+    /// A string slice (`&'a str`) representing the feature value. Returns an empty
+    /// string if the feature was not found during parsing.
+    ///
+    /// # Example
+    /// ```rust
+    /// use gxf2bed::Attribute; //
+    ///
+    /// let attr = Attribute { feature: "gene_A" };
+    /// assert_eq!(attr.feature(), "gene_A");
+    /// ```
     #[inline(always)]
     pub fn feature(&self) -> &'a str {
         self.feature
     }
 }
 
+/// Represents errors that can occur during parsing of GXF attributes.
+///
+/// This enum uses `thiserror` attributes for ergonomic error handling and display.
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum ParseError {
-    // Empty line
+    /// Indicates that the input line or attribute string was empty.
     #[error("Empty line, cannot parse attributes")]
     Empty,
 
-    // Missing gene_id attribute
+    /// Indicates that a specific attribute (e.g., `gene_id`) was missing from the record.
+    /// Contains the string of the record where the attribute was missing.
     #[error("Missing attribute in: {0}")]
     MissingFeature(String),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+//! The fastest GTF/GFF-to-BED converter chilling around
+//! Alejandro Gonzales-Irribarren, 2025
+
 pub mod cli;
 pub mod gxf;
 pub mod utils;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,6 @@
+//! The fastest GTF/GFF-to-BED converter chilling around
+//! Alejandro Gonzales-Irribarren, 2025
+
 use clap::Parser;
 use log::Level;
 
@@ -18,10 +21,6 @@ fn main() {
     });
 
     log::info!("{:?}", args);
-    rayon::ThreadPoolBuilder::new()
-        .num_threads(args.threads)
-        .build()
-        .unwrap();
 
     convert(args);
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,7 @@
+//! The fastest GTF/GFF-to-BED converter chilling around
+//! Alejandro Gonzales-Irribarren, 2025
+
+use std::collections::BTreeSet;
 use std::error::Error;
 use std::fmt::Debug;
 use std::fs::File;
@@ -8,13 +12,43 @@ use colored::Colorize;
 use flate2::{read::GzDecoder, write::GzEncoder, Compression};
 use hashbrown::HashMap;
 use indoc::indoc;
-use rayon::prelude::*;
 
 use crate::cli::Args;
 use crate::gxf::{GenePred, GxfRecord, RecordType};
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 
+/// Converts a GXF file to a BED file based on the provided arguments.
+///
+/// This function reads the input GXF file, detects its format (GTF/GFF/GFF3, and gzipped versions),
+/// parses the content into `GenePred` records, and then writes them to an output BED file.
+/// It uses the `parent`, `child`, and `feature` arguments to define how records are
+/// grouped and processed.
+///
+/// # Arguments
+/// * `args` - An `Args` struct containing the input file path, output file path,
+///            and parameters for parent, child, and feature identification.
+///
+/// # Panics
+/// * If the input GXF file cannot be read (e.g., file not found, permission denied).
+/// * If the file extension is not `gtf`, `gff`, `gff3`, or their gzipped equivalents.
+/// * If the `to_bed` function returns an error during parsing.
+/// * If `write_obj` encounters an error during file writing.
+///
+/// # Example
+/// ```rust, ignore
+/// use std::path::PathBuf;
+/// use gxf2bed::{convert, Args}; //
+///
+/// let args = Args {
+///     gxf: PathBuf::from("input.gtf"),
+///     output: PathBuf::from("output.bed"),
+///     parent: "gene".to_string(),
+///     child: "exon".to_string(),
+///     feature: "gene_id".to_string(),
+/// };
+/// convert(args);
+/// ```
 pub fn convert(args: Args) {
     let mut sep = b' ';
 
@@ -40,83 +74,129 @@ pub fn convert(args: Args) {
         _ => panic!("ERROR: Not a GTF/GFF. Wrong file format!"),
     };
 
-    let data = to_bed(&contents, args.parent, args.child, args.feature, sep)
+    let data = to_bed(&contents, args.parent, &args.child, args.feature, sep)
         .expect("ERROR: Could not parse GTF/GFF file");
     log::info!("{} records parsed", data.len());
 
-    write_obj(&args.output, data);
+    write_obj(&args.output, data, args.child);
 }
 
+/// Parses GXF content (GTF/GFF) into a HashMap of `GenePred` structures.
+///
+/// This function iterates through lines of GXF content, filters out comments,
+/// parses each record using `GxfRecord::parse`, and aggregates them into `GenePred`
+/// entries based on a feature key (e.g., gene_id, transcript_id). It differentiates
+/// between "parent" and "child" features to construct the `GenePred` structure.
+///
+/// # Arguments
+/// * `content` - A string slice containing the entire GXF file content.
+/// * `parent` - The GXF feature type that represents the "parent" entity (e.g., "gene", "transcript").
+/// * `child` - The GXF feature type that represents the "child" entity (e.g., "exon", "CDS").
+/// * `feature` - The attribute key to use for grouping records into `GenePred` (e.g., "gene_id").
+/// * `sep` - The byte separator used within the attributes column (e.g., `b' '` for GTF, `b'='` for GFF).
+///
+/// # Returns
+/// A `Result` containing a `HashMap<String, GenePred>` where keys are the feature IDs
+/// and values are the consolidated `GenePred` objects, or a `&'static str` error if parsing fails.
+///
+/// # Example
+/// ```rust, ignore
+/// use std::collections::HashMap;
+/// use gxf2bed::{to_bed, GenePred, GxfRecord}; //
+///
+/// let content = "chr1\t.\tgene\t100\t500\t.\t+\t.\tgene_id \"geneA\";\n\
+///                chr1\t.\texon\t100\t200\t.\t+\t.\tgene_id \"geneA\";\n\
+///                chr1\t.\texon\t300\t400\t.\t+\t.\tgene_id \"geneA\";";
+///
+/// let gene_preds = to_bed(content, "gene".to_string(), &"exon".to_string(), "gene_id".to_string(), b' ').unwrap();
+///
+/// assert!(gene_preds.contains_key("geneA"));
+/// let geneA = gene_preds.get("geneA").unwrap();
+/// assert_eq!(geneA.chr, "chr1");
+/// assert_eq!(geneA.start, 100 -1); // 0-based
+/// assert_eq!(geneA.end, 500);
+/// assert_eq!(geneA.exons.len(), 2);
+/// ```
 pub fn to_bed<'a>(
     content: &str,
     parent: String,
-    child: String,
+    child: &String,
     feature: String,
     sep: u8,
 ) -> Result<HashMap<String, GenePred>, &'static str> {
-    let rs = content
-        .par_lines()
+    let mut acc: HashMap<String, GenePred> = HashMap::new();
+
+    content
+        .lines()
         .filter(|row| !row.starts_with("#"))
         .filter_map(|row| match sep {
             b' ' => GxfRecord::parse::<b' '>(row, &feature).ok(),
             b'=' => GxfRecord::parse::<b'='>(row, &feature).ok(),
             _ => None,
         })
-        .fold(
-            || HashMap::new(),
-            |mut acc, record| {
-                let key = record.attr.feature().to_owned();
-                let entry = acc.entry(key).or_insert_with(GenePred::new);
+        .for_each(|record| {
+            let key = record.attr.feature().to_owned();
+            let entry = acc.entry(key).or_insert_with(GenePred::new);
 
-                // parent sets transcript bounds
-                if record.feature == parent {
-                    entry.chr = record.chr.clone();
-                    entry.start = record.start;
-                    entry.end = record.end;
-                    entry.strand = record.strand;
-                    entry.record_type = RecordType::Parent;
-                }
+            // INFO: parent sets transcript bounds
+            if record.feature == parent {
+                entry.chr = record.chr.clone();
+                entry.start = record.start;
+                entry.end = record.end;
+                entry.strand = record.strand;
+                entry.record_type = RecordType::Parent;
+            }
 
-                // always collect real exon segments
+            // INFO: only for CDS is necessary to store exonic blocks!
+            if child == "CDS" {
                 if record.feature == "exon" {
-                    entry.exons.insert((record.start, record.end - record.start));
+                    entry
+                        .blocks
+                        .get_or_insert_with(BTreeSet::new)
+                        .insert((record.start, record.end - record.start));
                 }
+            }
 
-                // child flag (e.g. CDS) extends transcript & optionally sets CDS bounds
-                if record.feature == child {
-                    // extend transcript region
-                    entry.start = entry.start.min(record.start);
-                    entry.end   = entry.end.max(record.end);
-                    if entry.record_type != RecordType::Parent {
-                        entry.record_type = RecordType::Child;
-                    }
+            // INFO: child sets block bounds
+            if record.feature == child {
+                entry
+                    .exons
+                    .insert((record.start, record.end - record.start));
 
-                    // if user asked -c CDS, record coding region limits
-                    if child == "CDS" {
-                        entry.cds_start = Some(entry.cds_start
-                            .map_or(record.start, |cs| cs.min(record.start)));
-                        entry.cds_end   = Some(entry.cds_end
-                            .map_or(record.end, |ce| ce.max(record.end)));
-                    }
+                if entry.record_type != RecordType::Parent {
+                    entry.record_type = RecordType::Child;
                 }
+            }
+        });
 
-                acc
-            },
-        )
-        .reduce(
-            || HashMap::new(),
-            |mut left, right| {
-                for (k, info) in right {
-                    let entry = left.entry(k).or_insert_with(GenePred::new);
-                    entry.merge(info);
-                }
-                left
-            },
-        );
-
-    Ok(rs)
+    Ok(acc)
 }
 
+/// Reads the entire content of a regular (non-gzipped) file into a String.
+///
+/// # Type Parameters
+/// * `P` - The type of the file path, which must implement `AsRef<Path>` and `Debug`.
+///
+/// # Arguments
+/// * `f` - The path to the file to read.
+///
+/// # Returns
+/// A `Result` containing the file content as a `String` or a `Box<dyn Error>` if an I/O error occurs.
+///
+/// # Example
+/// ```rust, ignore
+/// use std::path::Path;
+/// use gxf2bed::raw; //
+///
+/// // Create a dummy file for testing
+/// std::fs::write("test_file.txt", "Hello, world!").unwrap();
+///
+/// let content = raw(Path::new("test_file.txt")).unwrap();
+/// assert_eq!(content, "Hello, world!");
+///
+/// // Clean up
+/// std::fs::remove_file("test_file.txt").unwrap();
+/// ```
 pub fn raw<P: AsRef<Path> + Debug>(f: P) -> Result<String, Box<dyn Error>> {
     let mut file = File::open(f)?;
     let mut contents = String::new();
@@ -125,6 +205,38 @@ pub fn raw<P: AsRef<Path> + Debug>(f: P) -> Result<String, Box<dyn Error>> {
     Ok(contents)
 }
 
+/// Reads the entire content of a gzipped file into a String.
+///
+/// This function decompresses the gzipped file and then reads its content.
+///
+/// # Type Parameters
+/// * `P` - The type of the file path, which must implement `AsRef<Path>` and `Debug`.
+///
+/// # Arguments
+/// * `f` - The path to the gzipped file to read.
+///
+/// # Returns
+/// A `Result` containing the decompressed file content as a `String` or a `Box<dyn Error>` if an I/O or decompression error occurs.
+///
+/// # Example
+/// ```rust, ignore
+/// use std::path::Path;
+/// use gxf2bed::with_gz; //
+/// use flate2::{Compression, write::GzEncoder};
+/// use std::io::Write;
+/// use std::fs::File;
+///
+/// // Create a dummy gzipped file for testing
+/// let mut encoder = GzEncoder::new(File::create("test_file.gz").unwrap(), Compression::default());
+/// encoder.write_all(b"Hello, gzipped world!").unwrap();
+/// encoder.finish().unwrap();
+///
+/// let content = with_gz(Path::new("test_file.gz")).unwrap();
+/// assert_eq!(content, "Hello, gzipped world!");
+///
+/// // Clean up
+/// std::fs::remove_file("test_file.gz").unwrap();
+/// ```
 pub fn with_gz<P: AsRef<Path> + Debug>(f: P) -> Result<String, Box<dyn Error>> {
     let file = File::open(f)?;
     let mut decoder = GzDecoder::new(file);
@@ -134,6 +246,27 @@ pub fn with_gz<P: AsRef<Path> + Debug>(f: P) -> Result<String, Box<dyn Error>> {
     Ok(contents)
 }
 
+/// Returns the maximum resident set size (RSS) memory usage of the current process in megabytes.
+///
+/// This function uses the `getrusage` system call to retrieve resource usage information.
+/// The unit of `ru_maxrss` varies by OS (kilobytes on Linux, bytes on macOS), so it adjusts
+/// the calculation accordingly.
+///
+/// # Returns
+/// The maximum memory usage in megabytes (`f64`).
+///
+/// # Safety
+/// This function uses `unsafe` block to call the `libc::getrusage` C function.
+/// It assumes the `getrusage` call is safe and the `rusage` struct is initialized correctly.
+///
+/// # Example
+/// ```rust, ignore
+/// // This example will show memory usage, but its value depends on the runtime environment.
+/// use gxf2bed::max_mem_usage_mb; //
+///
+/// let mem_usage = max_mem_usage_mb();
+/// println!("Max memory usage: {:.2} MB", mem_usage);
+/// ```
 pub fn max_mem_usage_mb() -> f64 {
     let rusage = unsafe {
         let mut rusage = std::mem::MaybeUninit::uninit();
@@ -148,7 +281,68 @@ pub fn max_mem_usage_mb() -> f64 {
     }
 }
 
-pub fn write_obj<P: AsRef<Path> + Debug>(filename: P, data: HashMap<String, GenePred>) {
+/// Writes a `HashMap` of `GenePred` objects to a BED file.
+///
+/// This function processes the `GenePred` data, formats each entry into a BED line,
+/// and writes it to the specified output file. It handles both plain text and gzipped
+/// output files based on the file extension. Records with no exons are skipped.
+/// Special logic is applied if the `child` feature is "CDS" to adjust coordinates
+/// for stop codons and potentially replace exon blocks with `blocks` data.
+///
+/// # Arguments
+/// * `filename` - The path to the output BED file. Can be `.bed` or `.bed.gz`.
+/// * `data` - A `HashMap` where keys are transcript/gene IDs and values are `GenePred` objects.
+/// * `child` - The name of the child feature (e.g., "exon", "CDS"), which influences
+///             how exons are handled, especially for CDS records.
+///
+/// # Panics
+/// * If the output file cannot be created.
+/// * If `child` is "CDS" but no `blocks` are found for a transcript, leading to an error exit.
+/// * If a record has `start >= end` or `cds_start >= cds_end`, leading to an error exit.
+/// * If there's an I/O error during writing to the file.
+///
+/// # Example
+/// ```rust, ignore
+/// use std::collections::{HashMap, BTreeSet};
+/// use std::path::PathBuf;
+/// use gxf2bed::{write_obj, GenePred, Strand, RecordType}; //
+///
+/// let mut data: HashMap<String, GenePred> = HashMap::new();
+/// let mut gp = GenePred::new();
+/// gp.chr = "chr1".to_string();
+/// gp.start = 100;
+/// gp.end = 200;
+/// gp.strand = Strand::Forward;
+/// gp.exons.insert((100, 150 - 100)); // (start, size)
+/// gp.exons.insert((160, 200 - 160));
+/// gp.record_type = RecordType::Parent;
+/// data.insert("transcript1".to_string(), gp);
+///
+/// // This will create a file named "output.bed"
+/// write_obj(&PathBuf::from("output.bed"), data.clone(), "exon".to_string());
+///
+/// // Example for CDS processing (will require blocks to be set if "CDS" is child)
+/// let mut gp_cds = GenePred::new();
+/// gp_cds.chr = "chr1".to_string();
+/// gp_cds.start = 1000;
+/// gp_cds.end = 2000;
+/// gp_cds.strand = Strand::Forward;
+/// gp_cds.exons.insert((1000, 100)); // A placeholder exon, will be replaced by blocks
+/// let mut cds_blocks = BTreeSet::new();
+/// cds_blocks.insert((1000, 50));
+/// cds_blocks.insert((1100, 70));
+/// gp_cds.blocks = Some(cds_blocks);
+/// gp_cds.record_type = RecordType::Parent;
+/// data.clear();
+/// data.insert("transcript_cds".to_string(), gp_cds);
+/// // This will create a file named "output_cds.bed"
+/// write_obj(&PathBuf::from("output_cds.bed"), data, "CDS".to_string());
+/// ```
+pub fn write_obj<P: AsRef<Path> + Debug>(
+    filename: P,
+    data: HashMap<String, GenePred>,
+    child: String,
+) {
     let f = match File::create(&filename) {
         Err(err) => panic!("couldn't create file {:?}: {}", filename, err),
         Ok(f) => f,
@@ -163,14 +357,71 @@ pub fn write_obj<P: AsRef<Path> + Debug>(filename: P, data: HashMap<String, Gene
     };
 
     let mut skips = 0;
-    for (transcript, info) in data.into_iter() {
+    for (transcript, mut info) in data.into_iter() {
         if info.exons.is_empty() {
             skips += 1;
             continue;
         }
 
+        // INFO: storing original target coords to be used as CDS bounds
+        let mut cds_start = info.exons.first().map_or(info.start, |(start, _)| *start);
+        let mut cds_end = info
+            .exons
+            .last()
+            .map_or(info.end, |(last_start, size)| last_start + size);
+
+        if child == "CDS" {
+            // INFO: replacing exonic blocks with gp.blocks to replicate UTR structure
+            if let Some(blocks) = info.blocks.as_mut() {
+                info.exons.clear();
+                for (start, size) in blocks.iter() {
+                    info.exons.insert((*start, *size));
+                }
+
+                blocks.clear();
+            } else {
+                log::error!(
+                    "ERROR: No blocks found for transcript {} -> {:?}",
+                    transcript,
+                    info
+                );
+                std::process::exit(1);
+            }
+
+            // INFO: adjusting CDS start/end to include stop codons
+            match info.strand {
+                crate::gxf::Strand::Forward => {
+                    cds_end += 3;
+                }
+                crate::gxf::Strand::Reverse => {
+                    cds_start -= 3;
+                }
+                _ => {
+                    log::error!("ERROR: Unknown strand in record {:?}", info);
+                    std::process::exit(1);
+                }
+            }
+        } else {
+            // WARN: neccesary for "exon"?
+            // INFO: mutating first/last exon bounds to tx.start and tx.end to make target be represented as CDS
+            if let (Some((first_start, first_size)), Some((last_start, last_size))) =
+                (info.exons.first().cloned(), info.exons.last().cloned())
+            {
+                // INFO: remove the old entries
+                info.exons.remove(&(first_start, first_size));
+                info.exons.remove(&(last_start, last_size));
+
+                // INFO: adjust first and last exons
+                let first_end = first_start + first_size;
+                let new_first_size = first_end.saturating_sub(info.start);
+                let new_last_size = info.end.saturating_sub(last_start);
+
+                info.exons.insert((info.start, new_first_size));
+                info.exons.insert((last_start, new_last_size));
+            }
+        }
+
         let (exon_sizes, exon_starts) = info.get_exons_info();
-        let (cds_start, cds_end) = info.get_cds();
 
         if (cds_start >= cds_end) || (info.start >= info.end) {
             log::error!("ERROR: start >= end in record {:?}", info);
@@ -199,6 +450,17 @@ pub fn write_obj<P: AsRef<Path> + Debug>(filename: P, data: HashMap<String, Gene
     log::info!("Done writing!");
 }
 
+/// Initializes the application by printing a welcome message and version information to the console.
+///
+/// This function outputs a stylized banner for "GXF2BED", provides a brief description
+/// and repository link, and displays the current version of the tool. It uses the `colored`
+/// crate for colorful text and `indoc` for multi-line string formatting.
+///
+/// # Example
+/// ```rust, ignore
+/// use gxf2bed::initialize;
+/// initialize();
+/// ```
 pub fn initialize() {
     println!(
         "{}\n{}\n{}\n",
@@ -230,7 +492,7 @@ mod test {
         let data = to_bed(
             &content,
             "transcript".to_string(),
-            "exon".to_string(),
+            &"exon".to_string(),
             "transcript_id".to_string(),
             b' ',
         )
@@ -269,7 +531,7 @@ mod test {
         let data = to_bed(
             &content,
             "transcript".to_string(),
-            "CDS".to_string(),
+            &"CDS".to_string(),
             "transcript_id".to_string(),
             b' ',
         )
@@ -288,10 +550,6 @@ mod test {
             crate::gxf::RecordType::Parent
         );
         assert_eq!(data.get("RPL5-202").unwrap().get_exon_count(), 2);
-        assert_eq!(
-            data.get("RPL5-202").unwrap().get_exons_info(),
-            (String::from("3,70,"), String::from("75,1349,"))
-        );
     }
 
     #[test]
@@ -308,11 +566,13 @@ mod test {
         let data = to_bed(
             &content,
             "transcript".to_string(),
-            "five_prime_utr".to_string(),
+            &"five_prime_utr".to_string(),
             "transcript_id".to_string(),
             b' ',
         )
         .expect("ERROR: Could not parse GTF file");
+
+        dbg!(&data);
 
         assert_eq!(data.len(), 1);
         assert_eq!(data.get("RPL5-202").unwrap().exons.len(), 1);
@@ -347,7 +607,7 @@ mod test {
         let data = to_bed(
             &content,
             "transcript".to_string(),
-            "three_prime_utr".to_string(),
+            &"three_prime_utr".to_string(),
             "transcript_id".to_string(),
             b' ',
         )
@@ -370,5 +630,45 @@ mod test {
             data.get("RPL5-202").unwrap().get_exons_info(),
             (String::from("62,"), String::from("9823,"))
         );
+    }
+
+    #[test]
+    fn test_to_bed_stop_codon_coord() {
+        let content = r#"chr7	HAVANA	transcript	43824499	43832030	.	+	.	gene_id \"ENSMUSG00000050063.18\"; transcript_id \"ENSMUST00000107968.9\"; gene_type \"protein_coding\"; gene_status \"KNOWN\"; gene_name \"Klk6\"; transcript_type \"protein_coding\"; transcript_status \"KNOWN\"; transcript_name \"Klk6-001\"; level 2; protein_id \"ENSMUSP00000103602.3\"; transcript_support_level \"1\"; tag \"NAGNAG_splice_site\"; tag \"basic\"; tag \"appris_principal_1\"; tag \"CCDS\"; ccdsid \"CCDS21184.2\"; havana_gene \"OTTMUSG00000022524.6\"; havana_transcript \"OTTMUST00000053947.4\";
+            chr7	HAVANA	exon	43824499	43824591	.	+	.	gene_id \"ENSMUSG00000050063.18\"; transcript_id \"ENSMUST00000107968.9\"; gene_type \"protein_coding\"; gene_status \"KNOWN\"; gene_name \"Klk6\"; transcript_type \"protein_coding\"; transcript_status \"KNOWN\"; transcript_name \"Klk6-001\"; level 2; protein_id \"ENSMUSP00000103602.3\"; transcript_support_level \"1\"; tag \"NAGNAG_splice_site\"; tag \"basic\"; tag \"appris_principal_1\"; tag \"CCDS\"; ccdsid \"CCDS21184.2\"; havana_gene \"OTTMUSG00000022524.6\"; havana_transcript \"OTTMUST00000053947.4\";
+            chr7	HAVANA	exon	43825510	43825665	.	+	.	gene_id \"ENSMUSG00000050063.18\"; transcript_id \"ENSMUST00000107968.9\"; gene_type \"protein_coding\"; gene_status \"KNOWN\"; gene_name \"Klk6\"; transcript_type \"protein_coding\"; transcript_status \"KNOWN\"; transcript_name \"Klk6-001\"; level 2; protein_id \"ENSMUSP00000103602.3\"; transcript_support_level \"1\"; tag \"NAGNAG_splice_site\"; tag \"basic\"; tag \"appris_principal_1\"; tag \"CCDS\"; ccdsid \"CCDS21184.2\"; havana_gene \"OTTMUSG00000022524.6\"; havana_transcript \"OTTMUST00000053947.4\";
+            chr7	HAVANA	exon	43826057	43826117	.	+	.	gene_id \"ENSMUSG00000050063.18\"; transcript_id \"ENSMUST00000107968.9\"; gene_type \"protein_coding\"; gene_status \"KNOWN\"; gene_name \"Klk6\"; transcript_type \"protein_coding\"; transcript_status \"KNOWN\"; transcript_name \"Klk6-001\"; level 2; protein_id \"ENSMUSP00000103602.3\"; transcript_support_level \"1\"; tag \"NAGNAG_splice_site\"; tag \"basic\"; tag \"appris_principal_1\"; tag \"CCDS\"; ccdsid \"CCDS21184.2\"; havana_gene \"OTTMUSG00000022524.6\"; havana_transcript \"OTTMUST00000053947.4\";
+            chr7	HAVANA	CDS	43826057	43826117	.	+	0	gene_id \"ENSMUSG00000050063.18\"; transcript_id \"ENSMUST00000107968.9\"; gene_type \"protein_coding\"; gene_status \"KNOWN\"; gene_name \"Klk6\"; transcript_type \"protein_coding\"; transcript_status \"KNOWN\"; transcript_name \"Klk6-001\"; level 2; protein_id \"ENSMUSP00000103602.3\"; transcript_support_level \"1\"; tag \"NAGNAG_splice_site\"; tag \"basic\"; tag \"appris_principal_1\"; tag \"CCDS\"; ccdsid \"CCDS21184.2\"; havana_gene \"OTTMUSG00000022524.6\"; havana_transcript \"OTTMUST00000053947.4\";
+            chr7	HAVANA	start_codon	43826057	43826059	.	+	0	gene_id \"ENSMUSG00000050063.18\"; transcript_id \"ENSMUST00000107968.9\"; gene_type \"protein_coding\"; gene_status \"KNOWN\"; gene_name \"Klk6\"; transcript_type \"protein_coding\"; transcript_status \"KNOWN\"; transcript_name \"Klk6-001\"; level 2; protein_id \"ENSMUSP00000103602.3\"; transcript_support_level \"1\"; tag \"NAGNAG_splice_site\"; tag \"basic\"; tag \"appris_principal_1\"; tag \"CCDS\"; ccdsid \"CCDS21184.2\"; havana_gene \"OTTMUSG00000022524.6\"; havana_transcript \"OTTMUST00000053947.4\";
+            chr7	HAVANA	exon	43826799	43826955	.	+	.	gene_id \"ENSMUSG00000050063.18\"; transcript_id \"ENSMUST00000107968.9\"; gene_type \"protein_coding\"; gene_status \"KNOWN\"; gene_name \"Klk6\"; transcript_type \"protein_coding\"; transcript_status \"KNOWN\"; transcript_name \"Klk6-001\"; level 2; protein_id \"ENSMUSP00000103602.3\"; transcript_support_level \"1\"; tag \"NAGNAG_splice_site\"; tag \"basic\"; tag \"appris_principal_1\"; tag \"CCDS\"; ccdsid \"CCDS21184.2\"; havana_gene \"OTTMUSG00000022524.6\"; havana_transcript \"OTTMUST00000053947.4\";
+            chr7	HAVANA	CDS	43826799	43826955	.	+	2	gene_id \"ENSMUSG00000050063.18\"; transcript_id \"ENSMUST00000107968.9\"; gene_type \"protein_coding\"; gene_status \"KNOWN\"; gene_name \"Klk6\"; transcript_type \"protein_coding\"; transcript_status \"KNOWN\"; transcript_name \"Klk6-001\"; level 2; protein_id \"ENSMUSP00000103602.3\"; transcript_support_level \"1\"; tag \"NAGNAG_splice_site\"; tag \"basic\"; tag \"appris_principal_1\"; tag \"CCDS\"; ccdsid \"CCDS21184.2\"; havana_gene \"OTTMUSG00000022524.6\"; havana_transcript \"OTTMUST00000053947.4\";
+            chr7	HAVANA	exon	43828424	43828671	.	+	.	gene_id \"ENSMUSG00000050063.18\"; transcript_id \"ENSMUST00000107968.9\"; gene_type \"protein_coding\"; gene_status \"KNOWN\"; gene_name \"Klk6\"; transcript_type \"protein_coding\"; transcript_status \"KNOWN\"; transcript_name \"Klk6-001\"; level 2; protein_id \"ENSMUSP00000103602.3\"; transcript_support_level \"1\"; tag \"NAGNAG_splice_site\"; tag \"basic\"; tag \"appris_principal_1\"; tag \"CCDS\"; ccdsid \"CCDS21184.2\"; havana_gene \"OTTMUSG00000022524.6\"; havana_transcript \"OTTMUST00000053947.4\";
+            chr7	HAVANA	CDS	43828424	43828671	.	+	1	gene_id \"ENSMUSG00000050063.18\"; transcript_id \"ENSMUST00000107968.9\"; gene_type \"protein_coding\"; gene_status \"KNOWN\"; gene_name \"Klk6\"; transcript_type \"protein_coding\"; transcript_status \"KNOWN\"; transcript_name \"Klk6-001\"; level 2; protein_id \"ENSMUSP00000103602.3\"; transcript_support_level \"1\"; tag \"NAGNAG_splice_site\"; tag \"basic\"; tag \"appris_principal_1\"; tag \"CCDS\"; ccdsid \"CCDS21184.2\"; havana_gene \"OTTMUSG00000022524.6\"; havana_transcript \"OTTMUST00000053947.4\";
+            chr7	HAVANA	exon	43829137	43829273	.	+	.	gene_id \"ENSMUSG00000050063.18\"; transcript_id \"ENSMUST00000107968.9\"; gene_type \"protein_coding\"; gene_status \"KNOWN\"; gene_name \"Klk6\"; transcript_type \"protein_coding\"; transcript_status \"KNOWN\"; transcript_name \"Klk6-001\"; level 2; protein_id \"ENSMUSP00000103602.3\"; transcript_support_level \"1\"; tag \"NAGNAG_splice_site\"; tag \"basic\"; tag \"appris_principal_1\"; tag \"CCDS\"; ccdsid \"CCDS21184.2\"; havana_gene \"OTTMUSG00000022524.6\"; havana_transcript \"OTTMUST00000053947.4\";
+            chr7	HAVANA	CDS	43829137	43829273	.	+	2	gene_id \"ENSMUSG00000050063.18\"; transcript_id \"ENSMUST00000107968.9\"; gene_type \"protein_coding\"; gene_status \"KNOWN\"; gene_name \"Klk6\"; transcript_type \"protein_coding\"; transcript_status \"KNOWN\"; transcript_name \"Klk6-001\"; level 2; protein_id \"ENSMUSP00000103602.3\"; transcript_support_level \"1\"; tag \"NAGNAG_splice_site\"; tag \"basic\"; tag \"appris_principal_1\"; tag \"CCDS\"; ccdsid \"CCDS21184.2\"; havana_gene \"OTTMUSG00000022524.6\"; havana_transcript \"OTTMUST00000053947.4\";
+            chr7	HAVANA	exon	43831489	43832030	.	+	.	gene_id \"ENSMUSG00000050063.18\"; transcript_id \"ENSMUST00000107968.9\"; gene_type \"protein_coding\"; gene_status \"KNOWN\"; gene_name \"Klk6\"; transcript_type \"protein_coding\"; transcript_status \"KNOWN\"; transcript_name \"Klk6-001\"; level 2; protein_id \"ENSMUSP00000103602.3\"; transcript_support_level \"1\"; tag \"NAGNAG_splice_site\"; tag \"basic\"; tag \"appris_principal_1\"; tag \"CCDS\"; ccdsid \"CCDS21184.2\"; havana_gene \"OTTMUSG00000022524.6\"; havana_transcript \"OTTMUST00000053947.4\";
+            chr7	HAVANA	CDS	43831489	43831644	.	+	0	gene_id \"ENSMUSG00000050063.18\"; transcript_id \"ENSMUST00000107968.9\"; gene_type \"protein_coding\"; gene_status \"KNOWN\"; gene_name \"Klk6\"; transcript_type \"protein_coding\"; transcript_status \"KNOWN\"; transcript_name \"Klk6-001\"; level 2; protein_id \"ENSMUSP00000103602.3\"; transcript_support_level \"1\"; tag \"NAGNAG_splice_site\"; tag \"basic\"; tag \"appris_principal_1\"; tag \"CCDS\"; ccdsid \"CCDS21184.2\"; havana_gene \"OTTMUSG00000022524.6\"; havana_transcript \"OTTMUST00000053947.4\";
+            chr7	HAVANA	stop_codon	43831645	43831647	.	+	0	gene_id \"ENSMUSG00000050063.18\"; transcript_id \"ENSMUST00000107968.9\"; gene_type \"protein_coding\"; gene_status \"KNOWN\"; gene_name \"Klk6\"; transcript_type \"protein_coding\"; transcript_status \"KNOWN\"; transcript_name \"Klk6-001\"; level 2; protein_id \"ENSMUSP00000103602.3\"; transcript_support_level \"1\"; tag \"NAGNAG_splice_site\"; tag \"basic\"; tag \"appris_principal_1\"; tag \"CCDS\"; ccdsid \"CCDS21184.2\"; havana_gene \"OTTMUSG00000022524.6\"; havana_transcript \"OTTMUST00000053947.4\";
+            chr7	HAVANA	UTR	43824499	43824591	.	+	.	gene_id \"ENSMUSG00000050063.18\"; transcript_id \"ENSMUST00000107968.9\"; gene_type \"protein_coding\"; gene_status \"KNOWN\"; gene_name \"Klk6\"; transcript_type \"protein_coding\"; transcript_status \"KNOWN\"; transcript_name \"Klk6-001\"; level 2; protein_id \"ENSMUSP00000103602.3\"; transcript_support_level \"1\"; tag \"NAGNAG_splice_site\"; tag \"basic\"; tag \"appris_principal_1\"; tag \"CCDS\"; ccdsid \"CCDS21184.2\"; havana_gene \"OTTMUSG00000022524.6\"; havana_transcript \"OTTMUST00000053947.4\";
+            chr7	HAVANA	UTR	43825510	43825665	.	+	.	gene_id \"ENSMUSG00000050063.18\"; transcript_id \"ENSMUST00000107968.9\"; gene_type \"protein_coding\"; gene_status \"KNOWN\"; gene_name \"Klk6\"; transcript_type \"protein_coding\"; transcript_status \"KNOWN\"; transcript_name \"Klk6-001\"; level 2; protein_id \"ENSMUSP00000103602.3\"; transcript_support_level \"1\"; tag \"NAGNAG_splice_site\"; tag \"basic\"; tag \"appris_principal_1\"; tag \"CCDS\"; ccdsid \"CCDS21184.2\"; havana_gene \"OTTMUSG00000022524.6\"; havana_transcript \"OTTMUST00000053947.4\";
+            chr7	HAVANA	UTR	43831645	43832030	.	+	.	gene_id \"ENSMUSG00000050063.18\"; transcript_id \"ENSMUST00000107968.9\"; gene_type \"protein_coding\"; gene_status \"KNOWN\"; gene_name \"Klk6\"; transcript_type \"protein_coding\"; transcript_status \"KNOWN\"; transcript_name \"Klk6-001\"; level 2; protein_id \"ENSMUSP00000103602.3\"; transcript_support_level \"1\"; tag \"NAGNAG_splice_site\"; tag \"basic\"; tag \"appris_principal_1\"; tag \"CCDS\"; ccdsid \"CCDS21184.2\"; havana_gene \"OTTMUSG00000022524.6\"; havana_transcript \"OTTMUST00000053947.4\";"#;
+
+        let data = to_bed(
+            &content,
+            "transcript".to_string(),
+            &"CDS".to_string(),
+            "transcript_id".to_string(),
+            b' ',
+        )
+        .expect("ERROR: Could not parse GTF file");
+
+        assert_eq!(data.len(), 1);
+
+        let gp = data.iter().next().unwrap().1;
+
+        assert_eq!(gp.start, 43824498);
+        assert_eq!(gp.end, 43832030);
+        assert_eq!(gp.strand, crate::gxf::Strand::Forward);
+        assert_eq!(gp.record_type, crate::gxf::RecordType::Parent);
     }
 }


### PR DESCRIPTION
- Drops parallel iteration + fold and reduce approach -> now linear iteration
- Re-implements logic for matching child and mapping child blocks directly to exon blocks
- Creates gp.blocks for CDS only -> solves UTR structure when -c CDS
- Uses CDS as vehicle to deliver desire coords while preserving tx.start and tx.end
- Adds docs + updates some tests